### PR TITLE
容忍Kafka集群某些节点挂掉

### DIFF
--- a/src/Broker.php
+++ b/src/Broker.php
@@ -211,7 +211,8 @@ class Broker
                 return $client;
             }
         } catch (\Throwable $exception) {
-            throw new Exception\Exception($exception);
+            // throw new Exception\Exception($exception);
+            throw $exception;
         }
         return null;
     }


### PR DESCRIPTION
当节点发生变动的时候，服务默认会捕捉到error code然后重新sync元数据。
但是在同步元数据时，默认会连接所有的broker，并且有一个连接不上便会抛出异常重启消费者。
实际上，我们只要同步成功一次MetaData就可以保证集群可用，所以这里加了一个flag，并吞掉了connection的异常，只有当所有的broker都连不上时，才抛出错误。