### PR TITLE
fix: commit next offset

### DIFF
--- a/src/Consumer/Process.php
+++ b/src/Consumer/Process.php
@@ -332,7 +332,8 @@ class Process extends BaseProcess
                     if (!empty($message)) {
                         array_push($fetchMessage, $message);
                         $this->messages[$topic['topicName']][$part['partition']][] = $message;
-                        $offset = $message['offset'];// 当前消息的偏移量
+                        // 当前消息的偏移量
+                        $offset = ($part['highwaterMarkOffset'] > $message['offset']) ? ($message['offset'] + 1) : $message['offset'];
                         $this->getAssignment()->setCommitOffset($topic['topicName'], $part['partition'], $offset);
                     }
                 }


### PR DESCRIPTION
Increase the commit offset like the consumer offset. Without this, the topic lag is aways 1 because consumers using easyswoole/kafka will always be 1 message behind the partition offset.